### PR TITLE
Implement create employee endpoint

### DIFF
--- a/src/main/kotlin/org/hyperskill/phonebook/controller/EmployeeController.kt
+++ b/src/main/kotlin/org/hyperskill/phonebook/controller/EmployeeController.kt
@@ -1,6 +1,7 @@
 package org.hyperskill.phonebook.controller
 
 
+import jakarta.validation.Valid
 import org.hyperskill.phonebook.dtos.CreateEmployeeRequest
 import org.hyperskill.phonebook.model.Employee
 import org.hyperskill.phonebook.service.EmployeeServices
@@ -28,7 +29,7 @@ class EmployeeController(
     }
 
     @PostMapping
-    fun store(@RequestBody createEmployeeRequest: CreateEmployeeRequest): ResponseEntity<Employee> {
+    fun store(@RequestBody @Valid createEmployeeRequest: CreateEmployeeRequest): ResponseEntity<Employee> {
         val employee = employeeServices.store(createEmployeeRequest)
         return ResponseEntity(employee, HttpStatus.CREATED)
     }

--- a/src/main/kotlin/org/hyperskill/phonebook/controller/EmployeeController.kt
+++ b/src/main/kotlin/org/hyperskill/phonebook/controller/EmployeeController.kt
@@ -1,10 +1,15 @@
 package org.hyperskill.phonebook.controller
 
 
+import org.hyperskill.phonebook.dtos.CreateEmployeeRequest
 import org.hyperskill.phonebook.model.Employee
 import org.hyperskill.phonebook.service.EmployeeServices
 import org.springframework.data.domain.Page
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -22,4 +27,9 @@ class EmployeeController(
         return employeeServices.getAllEmployees(page)
     }
 
+    @PostMapping
+    fun store(@RequestBody createEmployeeRequest: CreateEmployeeRequest): ResponseEntity<Employee> {
+        val employee = employeeServices.store(createEmployeeRequest)
+        return ResponseEntity(employee, HttpStatus.CREATED)
+    }
 }

--- a/src/main/kotlin/org/hyperskill/phonebook/dtos/CreateEmployeeRequest.kt
+++ b/src/main/kotlin/org/hyperskill/phonebook/dtos/CreateEmployeeRequest.kt
@@ -1,11 +1,22 @@
 package org.hyperskill.phonebook.dtos
 
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
 import java.util.*
 
 data class CreateEmployeeRequest(
+    @field:NotBlank
     val name: String,
+
+    @field:NotBlank
     val position: String,
+
+    @field:NotBlank
     val phone: String,
+
+    @field:Email
     val email: String?,
+
+    @field:org.hibernate.validator.constraints.UUID
     val departmentId: UUID?
 )

--- a/src/main/kotlin/org/hyperskill/phonebook/dtos/CreateEmployeeRequest.kt
+++ b/src/main/kotlin/org/hyperskill/phonebook/dtos/CreateEmployeeRequest.kt
@@ -17,6 +17,5 @@ data class CreateEmployeeRequest(
     @field:Email
     val email: String?,
 
-    @field:org.hibernate.validator.constraints.UUID
     val departmentId: UUID?
 )

--- a/src/main/kotlin/org/hyperskill/phonebook/dtos/CreateEmployeeRequest.kt
+++ b/src/main/kotlin/org/hyperskill/phonebook/dtos/CreateEmployeeRequest.kt
@@ -5,16 +5,16 @@ import jakarta.validation.constraints.NotBlank
 import java.util.*
 
 data class CreateEmployeeRequest(
-    @field:NotBlank
+    @field:NotBlank(message = "Name must not be blank")
     val name: String,
 
-    @field:NotBlank
+    @field:NotBlank(message = "Position must not be blank")
     val position: String,
 
-    @field:NotBlank
+    @field:NotBlank(message = "Phone must not be blank")
     val phone: String,
 
-    @field:Email
+    @field:Email(message = "Email must be a valid email address")
     val email: String?,
 
     val departmentId: UUID?

--- a/src/main/kotlin/org/hyperskill/phonebook/exception/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/org/hyperskill/phonebook/exception/ControllerExceptionHandler.kt
@@ -1,0 +1,39 @@
+package org.hyperskill.phonebook.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.context.request.WebRequest
+import java.time.LocalDateTime
+
+@ControllerAdvice
+class ControllerExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValidException(
+        ex: MethodArgumentNotValidException,
+        request: WebRequest
+    ): ResponseEntity<CustomErrorMessage> {
+        val errorMessage = ex.bindingResult.fieldErrors.firstOrNull()?.defaultMessage ?: "Invalid request"
+        return ResponseEntity(
+            CustomErrorMessage(
+                status = 400,
+                timestamp = LocalDateTime.now(),
+                error = "Bad Request",
+                message = errorMessage,
+                path = request.getDescription(false)
+            ),
+            HttpStatus.BAD_REQUEST
+        )
+    }
+}
+
+data class CustomErrorMessage(
+    val status: Int,
+    val timestamp: LocalDateTime,
+    val error: String?,
+    val message: String?,
+    val path: String?,
+)

--- a/src/main/kotlin/org/hyperskill/phonebook/repository/DepartmentRepository.kt
+++ b/src/main/kotlin/org/hyperskill/phonebook/repository/DepartmentRepository.kt
@@ -1,0 +1,9 @@
+package org.hyperskill.phonebook.repository
+
+import org.hyperskill.phonebook.model.Department
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface DepartmentRepository : JpaRepository<Department, UUID>

--- a/src/main/kotlin/org/hyperskill/phonebook/service/EmployeeService.kt
+++ b/src/main/kotlin/org/hyperskill/phonebook/service/EmployeeService.kt
@@ -1,14 +1,18 @@
 package org.hyperskill.phonebook.service
 
+import org.hyperskill.phonebook.dtos.CreateEmployeeRequest
 import org.hyperskill.phonebook.model.Employee
+import org.hyperskill.phonebook.repository.DepartmentRepository
 import org.hyperskill.phonebook.repository.EmployeeRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
 class EmployeeServices(
     private val employeeRepository: EmployeeRepository,
+    private val departmentRepository: DepartmentRepository
 ) {
 
     fun getAllEmployees(page: Int): Page<Employee> {
@@ -16,4 +20,16 @@ class EmployeeServices(
         return employeeRepository.findAll(pageRequest)
     }
 
+    fun store(createEmployeeRequest: CreateEmployeeRequest): Employee {
+        val department = createEmployeeRequest.departmentId?.let { departmentRepository.findByIdOrNull(it) }
+        val employee = Employee(
+            name = createEmployeeRequest.name,
+            position = createEmployeeRequest.position,
+            phone = createEmployeeRequest.phone,
+            email = createEmployeeRequest.email,
+            department = department
+        )
+
+        return employeeRepository.save(employee)
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 cspring.application.name=phonebook
+server.error.include-message=always
 
 # H2 Database Configuration
 spring.datasource.url=jdbc:h2:mem:phonebookdb

--- a/src/test/kotlin/org/hyperskill/phonebook/controller/EmployeeControllerTest.kt
+++ b/src/test/kotlin/org/hyperskill/phonebook/controller/EmployeeControllerTest.kt
@@ -1,0 +1,150 @@
+package org.hyperskill.phonebook.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.hyperskill.phonebook.dtos.CreateEmployeeRequest
+import org.hyperskill.phonebook.model.Department
+import org.hyperskill.phonebook.model.Division
+import org.hyperskill.phonebook.model.Employee
+import org.hyperskill.phonebook.service.EmployeeServices
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.time.Instant
+import java.util.*
+
+@WebMvcTest(EmployeeController::class)
+internal class EmployeeControllerTest(
+    @Autowired private val mockMvc: MockMvc
+) {
+
+    @field:MockitoBean
+    private lateinit var employeeServices: EmployeeServices
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    private val mockDepartmentId = UUID.fromString("660e8400-e29b-41d4-a716-446655440001")
+
+    private val mockDivision = Division(
+        id = UUID.fromString("550e8400-e29b-41d4-a716-446655440001"), name = "Information Technology", isActive = true
+    )
+
+    private val mockDepartment = Department(
+        id = mockDepartmentId,
+        name = "Software Development",
+        division = mockDivision,
+        isActive = true,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now()
+    )
+
+    private val mockCreateEmployeeRequest = CreateEmployeeRequest(
+        name = "John Doe",
+        position = "Software Engineer",
+        phone = "+1-555-0199",
+        email = "john.doe@company.com",
+        departmentId = mockDepartmentId
+    )
+
+    private val mockEmployee = Employee(
+        id = UUID.fromString("770e8400-e29b-41d4-a716-446655440001"),
+        name = "John Doe",
+        position = "Software Engineer",
+        phone = "+1-555-0199",
+        email = "john.doe@company.com",
+        department = mockDepartment,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+        isActive = true
+    )
+
+    @Test
+    @Throws(Exception::class)
+    fun `POST employees with valid request returns valid ResponseEntity`() {
+        `when`(employeeServices.store(mockCreateEmployeeRequest)).thenReturn(mockEmployee)
+
+        val requestBuilder = post("/api/employees").contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(mockCreateEmployeeRequest))
+
+        mockMvc.perform(requestBuilder).andExpectAll(
+                status().isCreated,
+                content().contentType(MediaType.APPLICATION_JSON),
+                jsonPath("$.id").value(mockEmployee.id.toString()),
+                jsonPath("$.name").value("John Doe"),
+                jsonPath("$.position").value("Software Engineer"),
+                jsonPath("$.phone").value("+1-555-0199"),
+                jsonPath("$.email").value("john.doe@company.com"),
+                jsonPath("$.active").value(true)
+            )
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `POST employees with minimal valid request returns created`() {
+        val requestBuilder = post("/api/employees").contentType(MediaType.APPLICATION_JSON).content(
+                """
+                {
+                  "name": "test",
+                  "position": "test",
+                  "phone": "test"
+                }
+            """.trimIndent()
+            )
+
+        mockMvc.perform(requestBuilder).andExpect(status().isCreated)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `POST employees with invalid request returns bad request`() {
+        val requestBuilder = post("/api/employees").contentType(MediaType.APPLICATION_JSON).content(
+                """
+                {
+                  "name": "test"
+                }
+            """.trimIndent()
+            )
+
+        mockMvc.perform(requestBuilder).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `POST employees with invalid email returns bad request`() {
+        val requestBuilder = post("/api/employees").contentType(MediaType.APPLICATION_JSON).content(
+                """
+                {
+                  "name": "test",
+                  "position": "test",
+                  "phone": "test",
+                  "email": "test"
+                }
+            """.trimIndent()
+            )
+
+        mockMvc.perform(requestBuilder).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `POST employees with invalid uuid returns bad request`() {
+        val requestBuilder = post("/api/employees").contentType(MediaType.APPLICATION_JSON).content(
+                """
+                {
+                  "name": "test",
+                  "position": "test",
+                  "phone": "test",
+                  "departmentId": "this-is-not-uuid"
+                }
+            """.trimIndent()
+            )
+
+        mockMvc.perform(requestBuilder).andExpect(status().isBadRequest)
+    }
+}


### PR DESCRIPTION
- Employee Endpoint: Added a `POST` endpoint in `EmployeeController` to create employees using the `CreateEmployeeRequest` DTO, returning a `ResponseEntity` with `HttpStatus.CREATED`.
- Validation: Add validation annotation in the `CreateEmployeeRequest` DTO, such as `@NotBlank` for required fields and `@Email` for email validation.
- Exception Handling: Added `ControllerExceptionHandler` to handle validation errors (Return `CreateEmployeeRequest` DTO default message instead of exception message) 
- Unit Tests for Employee Creation: Added tests in `EmployeeControllerTest` to validate the behavior of the `POST` endpoint, including handling valid requests, minimal requests, invalid inputs, and cases like invalid email or UUID formats.
- Department Repository: Created `DepartmentRepository` to fetch departments by ID.
- Error Message Visibility: Updated `application.properties` to include error messages in the server response for easier debugging.